### PR TITLE
Test github app & reviewdog

### DIFF
--- a/src/logic/operate.js
+++ b/src/logic/operate.js
@@ -1,4 +1,4 @@
-import Big from 'big.js';
+import Big from "big.js";
 
 export default function operate(numberOne, numberTwo, operation) {
   const one = Big(numberOne || '0');
@@ -12,12 +12,12 @@ export default function operate(numberOne, numberTwo, operation) {
   if (operation === 'x') {
     return one.times(two).toString();
   }
-  if (operation === '÷') {
+  if (operation == '÷') {
     if (two === '0') {
       alert('Divide by 0 error');
       return '0';
     }
     return one.div(two).toString();
   }
-  throw Error(`Unknown operation '${operation}'`);
+  throw Error(`Unknown operation '${operation}'`)
 }


### PR DESCRIPTION
## Background
TODO

## Solution
TODO

`npx eslint --ext .js,.jsx,.ts,.tsx --fix src/`

<details>
  <summary>On master</summary>

```js
/Users/adiosmon/projects/calculator/src/index.jsx
   6:1   error  More than 1 blank line not allowed                         no-multiple-empty-lines
   7:51  error  Missing semicolon                                          semi
  10:1   error  Trailing spaces not allowed                                no-trailing-spaces
  10:1   error  Too many blank lines at the end of file. Max of 0 allowed  no-multiple-empty-lines
  10:2   error  Newline required at end of file but not found              eol-last

/Users/adiosmon/projects/calculator/src/logic/operate.js
  17:7  warning  Unexpected alert  no-alert

✖ 6 problems (5 errors, 1 warning)
  5 errors and 0 warnings potentially fixable with the `--fix` option.
```
</details>

<details>
  <summary>On current branch</summary>

```js
/Users/adiosmon/projects/calculator/src/index.jsx
   6:1   error  More than 1 blank line not allowed                         no-multiple-empty-lines
   7:51  error  Missing semicolon                                          semi
  10:1   error  Trailing spaces not allowed                                no-trailing-spaces
  10:1   error  Too many blank lines at the end of file. Max of 0 allowed  no-multiple-empty-lines
  10:2   error  Newline required at end of file but not found              eol-last

/Users/adiosmon/projects/calculator/src/logic/operate.js
   1:17  error    Strings must use singlequote         quotes
  15:17  error    Expected '===' and instead saw '=='  eqeqeq
  17:7   warning  Unexpected alert                     no-alert

✖ 8 problems (7 errors, 1 warning)
  6 errors and 0 warnings potentially fixable with the `--fix` option.
```
</details>

## TODO
- [ ] Github Checks should show only 2 problems, because they were introduced in this specific PR
- [ ] Instead of showing `ESLint — reviewdog [ESLint] report` it should show `ESLint — 8 problems (7 errors, 1 warning)`